### PR TITLE
make ex_doc dev-only dep

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule Geocalc.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-      { :ex_doc, "~> 0.10.0" }
+      { :ex_doc, "~> 0.10.0", only: :dev }
     ]
   end
 


### PR DESCRIPTION
Hi. This small project is cool. However please do make ex_doc dev-only dependency. This prevents from lingering of all this around-code stuff to productions of people who would want to use your app (including me). TIA