### PR TITLE
Add type Geocalc.DMS.t()

### DIFF
--- a/lib/geocalc/dms.ex
+++ b/lib/geocalc/dms.ex
@@ -7,6 +7,8 @@ defmodule Geocalc.DMS do
   @enforce_keys [:hours, :minutes, :seconds, :direction]
   defstruct [:hours, :minutes, :seconds, :direction]
 
+  @type t :: %Geocalc.DMS{}
+
   @doc """
   Converts `Geocalc.DMS` to decimal degrees
 


### PR DESCRIPTION
This type is missing and the app won't compile under Elixir 1.10 without it.