### PR TITLE
Fix dialyzer warning on Geocalc.crossing_parallels/3

### DIFF
--- a/lib/geocalc.ex
+++ b/lib/geocalc.ex
@@ -389,7 +389,7 @@ defmodule Geocalc do
       iex> Geocalc.crossing_parallels(point_1, point_2, latitude)
       {:error, "Not found"}
   """
-  @spec crossing_parallels(Point.t(), Point.t(), number) :: number
+  @spec crossing_parallels(Point.t(), Point.t(), number) :: tuple
   def crossing_parallels(point_1, path_2, latitude) do
     Calculator.crossing_parallels(point_1, path_2, latitude)
   end


### PR DESCRIPTION
This PR fixes the dialyzer warning as shown below:

```
lib/geocalc.ex:392:invalid_contract
The @spec for the function does not match the success typing of the function.

Function:
Geocalc.crossing_parallels/3

Success typing:
@spec crossing_parallels(_, _, _) :: {:error, <<_::72>>} | {:ok, float(), float()}
```